### PR TITLE
Create scanner microservice with FastAPI and Docker

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/scanner/main.py
+++ b/scanner/main.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import subprocess
+
+app = FastAPI()
+
+
+class DomainRequest(BaseModel):
+    domain: str
+
+
+class DomainResponse(BaseModel):
+    domain: str
+    status: str
+    output: str
+
+
+@app.post("/scan", response_model=DomainResponse)
+async def scan_domain(request: DomainRequest):
+    try:
+        command = ["echo", f"Scanning target: {request.domain}"]
+
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        return DomainResponse(
+            domain=request.domain,
+            status="success",
+            output=result.stdout.strip()
+        )
+
+    except subprocess.CalledProcessError as e:
+        raise HTTPException(status_code=500, detail=str(e.stderr))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/scanner/requirements.txt
+++ b/scanner/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## 🚀 Summary
This PR introduces a standalone microservice responsible for domain scanning operations. It is built with **FastAPI** and containerized using **Docker** to ensure isolation from the main Django application.

## 🛠️ Key Changes
- **New Microservice:** Created `scanner/` directory for the worker service.
- **FastAPI Setup:** Implemented `main.py` with a `POST /scan` endpoint.
- **Dockerization:** Added a `Dockerfile` using the lightweight `python:3.12-slim` image.
- **Dependencies:** Created `requirements.txt` for the scanner service.

## 🧪 How to Test
1. Navigate to the `scanner/` directory.
2. Build the image: `docker build -t scanner-app .`
3. Run the container: `docker run -p 8000:8000 scanner-app`
4. Visit `http://localhost:8000/docs` to test the API via Swagger UI.